### PR TITLE
Update: Shifting between time zones on service creation and retrieval

### DIFF
--- a/src/utils/availability/availabilityUtils.ts
+++ b/src/utils/availability/availabilityUtils.ts
@@ -6,7 +6,7 @@ import { validDays } from '../../validators/validator.custom';
 import { timeOnly } from './helpers';
 
 
-function createAvailabilityObjects(dayOrDate: string, availabilities: any[], sessionTime: number) {
+function createAvailabilityObjects(dayOrDate: string, availabilities: any[], sessionTime: number, userTimeZone: string) {
 
   const result: any[] = [];
 
@@ -20,12 +20,14 @@ function createAvailabilityObjects(dayOrDate: string, availabilities: any[], ses
         availability.duration,
         validDays.indexOf(dayOrDate),
       );
+      newAvailability.shiftToTimezone(userTimeZone, 'Etc/UTC'); // shift window time zone to UTC before proceeding
     } else {
       newAvailability = new AvailabilityException(
         Time.fromString(availability.startTime),
         availability.duration,
         new Date(dayOrDate),
       );
+      newAvailability.shiftToTimezone(userTimeZone, 'Etc/UTC'); // shift window time zone to UTC before proceeding
     }
 
     // check if the session time is greater than the new availability time window

--- a/src/utils/availability/helpers.ts
+++ b/src/utils/availability/helpers.ts
@@ -3,7 +3,7 @@ function timeOnly(hour: number, minute: number) {
 }
 
 const getDayName = (dayOfWeek: number): string => {
-  const days = ['saturday', 'sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday'];
+  const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
   return days[dayOfWeek];
 };
 


### PR DESCRIPTION
Updated the endpoints so that they convert time windows to UTC before checking for conflicts and storing to the database, and convert back to the user's time zone when retrieving the service